### PR TITLE
Fix Dia's issue

### DIFF
--- a/init_scripts/gnomad-init.sh
+++ b/init_scripts/gnomad-init.sh
@@ -4,7 +4,7 @@ set -x
 
 /opt/conda/bin/pip install --upgrade Cython
 PACKAGES="slackclient==2.0.0 sklearn tabulate scipy statsmodels ggplot hdbscan websocket-client"
-/opt/conda/bin/pip install --upgrade $PACKAGES
+/opt/conda/bin/pip install --upgrade --no-deps $PACKAGES
 
 #export HAIL_VERSION=devel
 #export SPARK_VERSION=2.2.0


### PR DESCRIPTION
`pip install --upgrade` also upgrades all dependencies. `slackclient==2.0.0` depends on `idna` and pip (maddeningly) blithely upgrades `idna` to the latest version even though it conflicts with several packages *already installed by pip*.

```
slackclient==2.0.0
  - aiodns [required: >1.0, installed: 2.0.0]
    - pycares [required: >=3.0.0, installed: 3.0.0]
      - cffi [required: >=1.5.0, installed: 1.12.3]
        - pycparser [required: Any, installed: 2.19]
    - typing [required: Any, installed: 3.6.6]
  - aiohttp [required: >3.5.2, installed: 3.5.4]
    - async-timeout [required: >=3.0,<4.0, installed: 3.0.1]
    - attrs [required: >=17.3.0, installed: 19.1.0]
    - chardet [required: >=2.0,<4.0, installed: 3.0.4]
    - idna-ssl [required: >=1.0, installed: 1.1.0]
      - idna [required: >=2.0, installed: 2.8]
    - multidict [required: >=4.0,<5.0, installed: 4.5.2]
    - typing-extensions [required: >=3.6.5, installed: 3.7.2]
    - yarl [required: >=1.0,<2.0, installed: 1.3.0]
      - idna [required: >=2.0, installed: 2.8]
      - multidict [required: >=4.0, installed: 4.5.2]
```