### PR TITLE
Removed hardcoded AD indices from get_adj_expr

### DIFF
--- a/utils/gnomad_functions.py
+++ b/utils/gnomad_functions.py
@@ -53,8 +53,8 @@ def get_adj_expr(
             (
                 hl.case()
                 .when(~gt_expr.is_het(), True)
-                .when(gt_expr.is_het_ref(), ad_expr[1] / dp_expr >= adj_ab)
-                .default((ad_expr[0] / dp_expr >= adj_ab ) & (ad_expr[1] / dp_expr >= adj_ab ))
+                .when(gt_expr.is_het_ref(), ad_expr[mt.GT[1]] / dp_expr >= adj_ab)
+                .default((ad_expr[mt.GT[0]] / dp_expr >= adj_ab ) & (ad_expr[mt.GT[1]] / dp_expr >= adj_ab ))
             )
     )
 

--- a/utils/gnomad_functions.py
+++ b/utils/gnomad_functions.py
@@ -53,8 +53,8 @@ def get_adj_expr(
             (
                 hl.case()
                 .when(~gt_expr.is_het(), True)
-                .when(gt_expr.is_het_ref(), ad_expr[mt.GT[1]] / dp_expr >= adj_ab)
-                .default((ad_expr[mt.GT[0]] / dp_expr >= adj_ab ) & (ad_expr[mt.GT[1]] / dp_expr >= adj_ab ))
+                .when(gt_expr.is_het_ref(), ad_expr[gt_expr[1]] / dp_expr >= adj_ab)
+                .default((ad_expr[gt_expr[0]] / dp_expr >= adj_ab ) & (ad_expr[gt_expr[1]] / dp_expr >= adj_ab ))
             )
     )
 


### PR DESCRIPTION
I noticed that the adj expression expects the input data to have only biallelics, but we annotate with adj before splitting multiallelics (https://github.com/macarthur-lab/gnomad_qc/blob/master/sample_qc/generate_hardcalls.py)