### PR TITLE
Fix syntax error in generate_fam_stats_expr

### DIFF
--- a/utils/variant_qc.py
+++ b/utils/variant_qc.py
@@ -1,3 +1,5 @@
+import itertools
+
 from .generic import *
 
 
@@ -160,10 +162,13 @@ def generate_fam_stats_expr(
     )
 
     fam_stats = fam_stats.select(
-        **{
-            f'n_transmitted_{name}': fam_stats[name][0],
-            f'n_untransmitted_{name}': fam_stats[name][1]
-        } for name in fam_stats
+        **dict(itertools.chain.from_iterable(
+            [
+                (f'n_transmitted_{name}', fam_stats[name][0]),
+                (f'n_untransmitted_{name}', fam_stats[name][1]),
+            ]
+            for name in fam_stats
+        ))
     )
 
     # Create de novo counters


### PR DESCRIPTION
Noticed this invalid syntax when trying to build docs.

This function was added in #124 and it looks like the syntax error got introduced in some changes (8ee887fd9216f91a3bdc7683a18beb364fec3f3f) made in response to the initial review.