### PR TITLE
Fixup docstrings for Sphinx

### DIFF
--- a/resources/variant_qc.py
+++ b/resources/variant_qc.py
@@ -60,8 +60,8 @@ def rf_path(data_type: str,
             hail_version: str = CURRENT_HAIL_VERSION
             ) -> str:
     """
-
     Gets the path to the desired RF data.
+
     Data can take the following values:
         - 'training': path to the training data for a given run
         - 'model': path to pyspark pipeline RF model
@@ -149,6 +149,7 @@ def binned_concordance_path(data_type: str, truth_data: str, metric: str) -> str
 def release_ht_path(data_type: str, release_tag=RELEASE_VERSION, nested=True, with_subsets=True, temp=False):
     '''
     Fetch filepath for release (variant-only) Hail Tables
+
     :param str data_type: 'exomes' or 'genomes'
     :param str release_tag: String describing release version for use in output filepaths
     :param bool nested: If True, fetch Table in which variant annotations (e.g., freq, popmax, faf, and age histograms)
@@ -173,6 +174,7 @@ def release_ht_path(data_type: str, release_tag=RELEASE_VERSION, nested=True, wi
 def release_vcf_path(data_type: str, release_tag=RELEASE_VERSION, contig=None, coding_only=False):
     '''
     Fetch filepath for release (variant-only) VCFs
+
     :param str data_type: 'exomes' or 'genomes'
     :param str release_tag: String describing release version for use in output filepaths
     :param str contig: String containing the name of the desired reference contig

--- a/utils/annotations.py
+++ b/utils/annotations.py
@@ -60,10 +60,10 @@ def project_max_expr(
     - homozygote_count: int32,
     - project: str
 
-    Notes
-    -----
-    Only projects with AF > 0 are returned.
-    In case of ties, the project ordering is not guaranteed, and at most `n_projects` are returned.
+    .. note::
+
+        Only projects with AF > 0 are returned.
+        In case of ties, the project ordering is not guaranteed, and at most `n_projects` are returned.
 
     :param StringExpression project_expr: column expression containing the project
     :param CallExpression gt_expr: entry expression containing the genotype
@@ -186,11 +186,11 @@ def qual_hist_expr(
     """
     Returns a struct expression with genotype quality histograms based on the arguments given (dp, gq, ad).
 
-    Notes
-    -----
-    - If `gt_expr` is provided, will return histograms for non-reference samples only as well as all samples.
-    - `gt_expr` is required for the allele-balance histogram, as it is only computed on het samples.
-    - If `adj_expr` is provided, additional histograms are computed using only adj samples.
+    .. note::
+
+        - If `gt_expr` is provided, will return histograms for non-reference samples only as well as all samples.
+        - `gt_expr` is required for the allele-balance histogram, as it is only computed on het samples.
+        - If `adj_expr` is provided, additional histograms are computed using only adj samples.
 
     :param CallExpression gt_expr: Entry expression containing genotype
     :param NumericExpression gq_expr: Entry expression containing genotype quality
@@ -263,16 +263,16 @@ def annotate_freq(
     Adds a row annotation `freq` to the input `mt` with stratified allele frequencies,
     and a global annotation `freq_meta` with metadata.
 
-    Notes
-    -----
-    Currently this only supports bi-allelic sites.
-    The input `mt` needs to have the following entry fields:
-    - GT: a CallExpression containing the genotype
-    - adj: a BooleanExpression containing whether the genotype is of high quality or not.
-    All expressions arguments need to be expression on the input `mt`.
+    .. note::
 
-    `freq` row annotation
-    ---------------------
+        Currently this only supports bi-allelic sites.
+        The input `mt` needs to have the following entry fields:
+        - GT: a CallExpression containing the genotype
+        - adj: a BooleanExpression containing whether the genotype is of high quality or not.
+        All expressions arguments need to be expression on the input `mt`.
+
+    .. rubric:: `freq` row annotation
+
     The `freq` row annotation is an Array of Struct, with each Struct containing the following fields:
     - AC: int32,
     - AF: float64,
@@ -282,14 +282,14 @@ def annotate_freq(
     Each element of the array corresponds to a stratification of the data,
     and the metadata about these annotations is stored in the globals.
 
-    Global `freq_meta` metadata annotation
-    --------------------------------------
+    .. rubric:: Global `freq_meta` metadata annotation
+
     The global annotation `freq_meta` is added to the input `mt`. It is a list of dict.
     Each element of the list contains metadata on a frequency stratification and the index in the list corresponds
     to the index of that frequency stratification in the `freq` row annotation.
 
-    The `downsamplings` parameter
-    -----------------------------
+    .. rubric:: The `downsamplings` parameter
+
     If the `downsamplings` parameter is used, frequencies will be computed for all samples and by population
     (if `pop_expr` is specified) by downsampling the number of samples without replacement to each of the numbers specified in the
     `downsamplings` array, provided that there are enough samples in the dataset.

--- a/utils/generic.py
+++ b/utils/generic.py
@@ -645,11 +645,10 @@ def phase_trio_matrix_by_transmission(tm: hl.MatrixTable, call_field: str = 'GT'
         2. Diploid father genotype calls on non-PAR region of X for a male proband (proband and mother are still phased as father doesn't participate in allele transmission)
 
 
-        Typical usage:
-        ```
+        Typical usage::
+
             trio_matrix = hl.trio_matrix(mt, ped)
             phased_trio_matrix = phase_trio_matrix_by_transmission(trio_matrix)
-        ```
 
         :param MatrixTable tm: Trio MatrixTable (entries should be a Struct with `proband_entry`, `mother_entry` and `father_entry` present)
         :param str call_field: genotype field name to phase
@@ -982,11 +981,11 @@ def assign_population_pcs(
         missing_label: str = 'oth'
 ) -> Tuple[Union[hl.Table, pd.DataFrame], Any]: # 2nd element of the tuple should be RandomForestClassifier but we do not want to import sklearn.RandomForestClassifier outside
     """
-
     This function uses a random forest model to assign population labels based on the results of PCA.
     Default values for model and assignment parameters are those used in gnomAD.
 
     As input, this function can either take:
+
     - A Hail Table (typically the output of `hwe_normalized_pca`). In this case,
         - `pc_cols` should be an ArrayExpression of Floats where each element is one of the PCs to use.
         - A Hail Table will be returned as output
@@ -994,10 +993,10 @@ def assign_population_pcs(
         - Each PC should be in a separate column and `pc_cols` is the list of all the columns containing the PCs to use.
         - A pandas DataFrame is returned as output
 
-    Note
-    ----
-    If you have a Pandas Dataframe and have all PCs as an array in a single column, the
-    `expand_pd_array_col` can be used to expand this column into multiple `PC` columns.
+    .. note::
+
+        If you have a Pandas Dataframe and have all PCs as an array in a single column, the
+        `expand_pd_array_col` can be used to expand this column into multiple `PC` columns.
 
     :param Table or DataFrame pop_pc_pd: Input Hail Table or Pandas Dataframe
     :param ArrayExpression or list of str pc_cols: Columns storing the PCs to use
@@ -1168,9 +1167,9 @@ def bi_allelic_site_inbreeding_expr(call: hl.expr.CallExpression) -> hl.expr.Flo
     This is implemented based on the GATK InbreedingCoeff metric:
     https://software.broadinstitute.org/gatk/documentation/article.php?id=8032
 
-    Note
-    ----
-    The computation is run based on the counts of alternate alleles and thus should only be run on bi-allelic sites.
+    .. note::
+
+        The computation is run based on the counts of alternate alleles and thus should only be run on bi-allelic sites.
 
     :param CallExpression call: Expression giving the calls in the MT
     :return: Site inbreeding coefficient expression
@@ -1230,18 +1229,18 @@ def fs_from_sb(
     In addition to the default GATK behavior, setting `normalize` to `False` will perform a chi-squared test
     for large counts (> `min_cell_count`) instead of normalizing the cell values.
 
-    Note
-    ----
-    This function can either take
-    - an array of length containing the table counts: [ref fwd, ref rev, alt fwd, alt rev]
-    - an array containig 2 arrays of length 2, containing the counts: [[ref fwd, ref rev], [alt fwd, alt rev]]
+    .. note::
+
+        This function can either take
+        - an array of length containing the table counts: [ref fwd, ref rev, alt fwd, alt rev]
+        - an array containig 2 arrays of length 2, containing the counts: [[ref fwd, ref rev], [alt fwd, alt rev]]
 
     GATK code here: https://github.com/broadinstitute/gatk/blob/master/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/FisherStrand.java
 
     :param ArrayNumericExpression or ArrayExpression sb: Count of ref/alt reads on each strand
-    :param bool normalize: Whether to normalize counts is sum(counts) > min_cell_count (`normalize`=True), or use a chi sq instead of FET (`normalize`=False)
+    :param bool normalize: Whether to normalize counts is sum(counts) > min_cell_count (normalize=True), or use a chi sq instead of FET (normalize=False)
     :param int min_cell_count: Maximum count for performing a FET
-    :param int min_count: Minimum total count to output `FS` (otherwise `null` it output)
+    :param int min_count: Minimum total count to output FS (otherwise null it output)
     :return: FS value
     :rtype: Int64Expression
     """

--- a/utils/gnomad_functions.py
+++ b/utils/gnomad_functions.py
@@ -285,13 +285,13 @@ def melt_kt(kt, columns_to_melt, key_column_name='variable', value_column_name='
     :param str value_column_name: What to call the value column
     :return: melted Key Table
     :rtype: KeyTable
-    return (kt
-            .annotate('comb = [{}]'.format(', '.join(['{{k: "{0}", value: {0}}}'.format(x) for x in columns_to_melt])))
-            .drop(columns_to_melt)
-            .explode('comb')
-            .annotate('{} = comb.k, {} = comb.value'.format(key_column_name, value_column_name))
-            .drop('comb'))
     """
+    # return (kt
+    #         .annotate('comb = [{}]'.format(', '.join(['{{k: "{0}", value: {0}}}'.format(x) for x in columns_to_melt])))
+    #         .drop(columns_to_melt)
+    #         .explode('comb')
+    #         .annotate('{} = comb.k, {} = comb.value'.format(key_column_name, value_column_name))
+    #         .drop('comb'))
     raise NotImplementedError
 
 
@@ -321,14 +321,14 @@ def melt_kt_grouped(kt, columns_to_melt, value_column_names, key_column_name='va
     | 1:2:A:G |      AFR |   100  |    10  |
     +---------+----------+--------+--------+
 
-    This is done with:
+    This is done with::
 
-    columns_to_melt = {
-        'NFE': ['AC_NFE', 'Hom_NFE'],
-        'AFR': ['AC_AFR', 'Hom_AFR']
-    }
-    value_column_names = ['AC', 'Hom']
-    key_column_name = 'pop'
+        columns_to_melt = {
+            'NFE': ['AC_NFE', 'Hom_NFE'],
+            'AFR': ['AC_AFR', 'Hom_AFR']
+        }
+        value_column_names = ['AC', 'Hom']
+        key_column_name = 'pop'
 
     Note that len(value_column_names) == len(columns_to_melt[i]) for all in columns_to_melt
 
@@ -338,28 +338,27 @@ def melt_kt_grouped(kt, columns_to_melt, value_column_names, key_column_name='va
     :param str key_column_name: What to call the key column
     :return: melted Key Table
     :rtype: KeyTable
-
-    if any([len(value_column_names) != len(v) for v in columns_to_melt.values()]):
-        logger.warning('Length of columns_to_melt sublist is not equal to length of value_column_names')
-        logger.warning('value_column_names = %s', value_column_names)
-        logger.warning('columns_to_melt = %s', columns_to_melt)
-
-    # I think this goes something like this:
-    fields = []
-    for k, v in columns_to_melt.items():
-        subfields = [': '.join(x) for x in zip(value_column_names, v)]
-        field = '{{k: "{0}", {1}}}'.format(k, ', '.join(subfields))
-        fields.append(field)
-
-    split_text = ', '.join(['{0} = comb.{0}'.format(x) for x in value_column_names])
-
-    return (kt
-            .annotate('comb = [{}]'.format(', '.join(fields)))
-            .drop([y for x in columns_to_melt.values() for y in x])
-            .explode('comb')
-            .annotate('{} = comb.k, {}'.format(key_column_name, split_text))
-            .drop('comb'))
     """
+    # if any([len(value_column_names) != len(v) for v in columns_to_melt.values()]):
+    #     logger.warning('Length of columns_to_melt sublist is not equal to length of value_column_names')
+    #     logger.warning('value_column_names = %s', value_column_names)
+    #     logger.warning('columns_to_melt = %s', columns_to_melt)
+
+    # # I think this goes something like this:
+    # fields = []
+    # for k, v in columns_to_melt.items():
+    #     subfields = [': '.join(x) for x in zip(value_column_names, v)]
+    #     field = '{{k: "{0}", {1}}}'.format(k, ', '.join(subfields))
+    #     fields.append(field)
+
+    # split_text = ', '.join(['{0} = comb.{0}'.format(x) for x in value_column_names])
+
+    # return (kt
+    #         .annotate('comb = [{}]'.format(', '.join(fields)))
+    #         .drop([y for x in columns_to_melt.values() for y in x])
+    #         .explode('comb')
+    #         .annotate('{} = comb.k, {}'.format(key_column_name, split_text))
+    #         .drop('comb'))
     raise NotImplementedError
 
 

--- a/utils/sample_qc.py
+++ b/utils/sample_qc.py
@@ -18,10 +18,10 @@ def filter_rows_for_qc(
     Annotates rows with `sites_callrate`, `site_inbreeding_coeff` and `af`, then applies thresholds.
     AF and callrate thresholds are taken from gnomAD QC; inbreeding coeff, MQ, FS and QD filters are taken from GATK best practices
 
-    Note
-    ----
-    This function expect the typical ``info`` annotation of type struct with fields ``MQ``, ``FS`` and ``QD``
-    if applying hard filters.
+    .. note::
+
+        This function expect the typical ``info`` annotation of type struct with fields ``MQ``, ``FS`` and ``QD``
+        if applying hard filters.
 
     :param MatrixTable mt: Input MT
     :param float min_af: Minimum site AF to keep. Not applied if set to ``None``.
@@ -179,11 +179,11 @@ def compute_callrate_mt(
     Computes a sample/interval MT with each entry containing the call rate for that sample/interval.
     This can be used as input for imputing exome sequencing platforms.
 
-    Note
-    ----
-    The input interval HT should have a key of type Interval.
-    The resulting table will have a key of the same type as the `intervals_ht` table and
-    contain an `interval_info` field containing all non-key fields of the `intervals_ht`.
+    .. note::
+
+        The input interval HT should have a key of type Interval.
+        The resulting table will have a key of the same type as the `intervals_ht` table and
+        contain an `interval_info` field containing all non-key fields of the `intervals_ht`.
 
     :param MatrixTable mt: Input MT
     :param Table intervals_ht: Table containing the intervals. This table has to be keyed by locus.

--- a/utils/sparse_mt.py
+++ b/utils/sparse_mt.py
@@ -236,7 +236,9 @@ def get_as_info_expr(
 ) -> hl.expr.StructExpression:
     """
     Returns an allele-specific annotation Struct containing typical VCF INFO fields from GVCF INFO fields stored in the MT entries.
+
     Notes:
+
     1. If `SB` is specified in array_sum_agg_fields, it will be aggregated as `AS_SB_TABLE`, according to GATK standard nomenclature.
     2. If `RAW_MQandDP` is specified in array_sum_agg_fields, it will be used for the `MQ` calculation and then dropped according to GATK recommendation.
     3. If `RAW_MQ` and `MQ_DP` are given, they will be used for the `MQ` calculation and then dropped according to GATK recommendation.
@@ -316,6 +318,7 @@ def get_site_info_expr(
     Creates a site-level annotation Struct aggregating typical VCF INFO fields from GVCF INFO fields stored in the MT entries.
 
     Notes:
+
     1. If `RAW_MQandDP` is specified in array_sum_agg_fields, it will be used for the `MQ` calculation and then dropped according to GATK recommendation.
     2. If `RAW_MQ` and `MQ_DP` are given, they will be used for the `MQ` calculation and then dropped according to GATK recommendation.
     3. If the fields to be aggregate (`sum_agg_fields`, `int32_sum_agg_fields`, `median_agg_fields`) are passed as list of str,

--- a/utils/variant_qc.py
+++ b/utils/variant_qc.py
@@ -12,8 +12,7 @@ def get_lowqual_expr(
         indel_phred_het_prior: 39  # 1/8,000
 ) -> Union[hl.expr.BooleanExpression, hl.expr.ArrayExpression]:
     """
-    Computes lowqual threshold expression for either split or unsplit alleles based on
-    (AS_)QUALapprox
+    Computes lowqual threshold expression for either split or unsplit alleles based on QUALapprox or AS_QUALapprox
 
     :param ArrayExpression alleles: Array of alleles
     :param ArraynumericExpression or NumericExpression qual_approx_expr: QUALapprox or AS_QUALapprox
@@ -205,14 +204,14 @@ def compute_binned_rank(
     If a single value in `score_expr` spans more than one bin, the rows with this value are distributed
     randomly across the bins it spans.
 
-    Notes
-    -----
-    The `rank_expr` defines which data the rank(s) should be computed on. E.g., to get an SNV rank and an Indel rank,
-    the following could be used:
-    rank_expr={
-       'snv_rank': hl.is_snp(ht.alleles[0], ht.alleles[1]),
-       'indels_rank': ~hl.is_snp(ht.alleles[0], ht.alleles[1])
-    }
+    .. note::
+
+        The `rank_expr` defines which data the rank(s) should be computed on. E.g., to get an SNV rank and an Indel rank,
+        the following could be used:
+        rank_expr={
+        'snv_rank': hl.is_snp(ht.alleles[0], ht.alleles[1]),
+        'indels_rank': ~hl.is_snp(ht.alleles[0], ht.alleles[1])
+        }
 
     :param Table ht: Input Table
     :param NumericExpression score_expr: Expression containing the score

--- a/utils/variant_qc_plots.py
+++ b/utils/variant_qc_plots.py
@@ -108,11 +108,10 @@ def plot_metric(df: pd.DataFrame,
 
     This function generates scatter plots with the metric bin on x-axis and a user-defined function on the y-axis.
     The data for the y-axis function needs to from the columns specified in `cols`. The function is specified with the `y_fun` argument and data columns are access as a list.
-    As an example, plotting Transition to transversion ratio is done as follows:
-    ```
-    plot_metric(snvs, 'Ti/Tv', ['n_ti', 'n_tv'], y_fun=lambda x: x[0]/x[1], colors=colors)
+    As an example, plotting Transition to transversion ratio is done as follows::
 
-    ```
+        plot_metric(snvs, 'Ti/Tv', ['n_ti', 'n_tv'], y_fun=lambda x: x[0]/x[1], colors=colors)
+
     In this command, `x[0]` correspond to the  first column selected (`'n_ti'`)  and `x[1]` to the second (`'n_tv'`).
 
 
@@ -427,8 +426,8 @@ def plot_concordance_pr(
     :param dict of str -> str colors: Optional colors to use (model name -> desired color)
     :param str size_prop: Either 'radius' or 'area' can be specified. If either is specified, the points will be sized proportionally to the amount of data in that point.
     :param list of int bins_to_label: Bins to label
-    :return Bokeh grid of plots
-    :rtype Tabs
+    :return: Bokeh grid of plots
+    :rtype: Tabs
     """
 
     if colors is None:


### PR DESCRIPTION
Some changes to docstrings were necessary to get Sphinx to build docs.

There are still several places that could use some [formatting](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html) improvements, but this is only the minimum change required to resolve all Sphinx's errors and warnings.