### PR TITLE
Add pylint configuration

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,6 @@
+[MESSAGES CONTROL]
+
+disable=
+  unused-wildcard-import,
+  R,
+  C

--- a/lint
+++ b/lint
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+
+pylint "$@" __init__.py resources utils tests


### PR DESCRIPTION
After finding a syntax error (#130) and a few uses of undefined variables, it seems like we could benefit from using a linter.

This adds a configuration file for [Pylint](https://www.pylint.org/) and a wrapper script to eventually be used in some automated checks.

The only non-default configuration in .pylintrc is in the messages control section. This configuration disables refactoring and convention messages (since we have enough errors and warnings to deal with) and also unused-wildcard-import warnings (since wildcard imports are used frequently here, enabling that rule generates thousands of warnings).

To use pylint, install it (`pip install pylint`) and run `./lint`.

If running in an environment without gnomad_hail's dependencies installed, pylint will generate many import related errors. To work around that, run `pylint -d import-error -d no-member __init__ resources utils tests`.