### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+hail
+hdbscan
+ipywidgets
+sklearn
+slackclient==2.0.0


### PR DESCRIPTION
Add a [requirements file](https://pip.pypa.io/en/stable/user_guide/#requirements-files) to document dependencies.

gnomad_hail also directly imports from the following packages that are installed as dependencies of Hail. I left them out of requirements.txt to avoid version conflicts with the Hail dependencies.
* bokeh
* numpy
* pandas
* pyspark


Resolves #132