### PR TITLE
Add job to run Pylint on pushes to master and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,29 @@ on:
       - master
   pull_request:
 jobs:
+  pylint:
+    name: Pylint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Use pip cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            pip-
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pylint
+      - name: Run Pylint
+        run: ./lint --disable=W
   docs:
     name: Build documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
Following on from #133, this adds a check to automatically run [Pylint](https://www.pylint.org/) on pushes to master and PRs.

This runs pylint with warning messages disabled. Refactor and convention messages are also disabled by the .pylintrc configuration. Thus, only fatal or error messages (syntax errors, undefined variables, etc) will prevent a PR from passing this status check.