### PR TITLE
Add link to API reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a number of [Hail](https://hail.is/) utility functions and scripts for the [gnomAD project](http://gnomad.broadinstitute.org) and the [MacArthur lab](http://macarthurlab.org). As we continue to expand the size of our datasets, we are constantly seeking to find ways to reduce the complexity of our workflows and to make these functions more generic. As a result, the interface for many of these functions will change over time as we generalize their implementation for more flexible use within our scripts. We are also continously adapting our code to regular changes in the Hail interface. These repos thus represent only a snapshot of the gnomAD code base and are shared without guarantees or warranties.
 
-We therefore encourage users to browse through the code and identify modules and functions that will be useful in their own pipelines, and to edit and reconfigure relevant code to suit their particular analysis and QC needs. 
+We therefore encourage users to browse through the [API reference](https://macarthur-lab.github.io/gnomad_hail/api_reference/) to identify modules and functions that will be useful in their own pipelines, and to edit and reconfigure relevant code to suit their particular analysis and QC needs.
 
 
 Load using:

--- a/docs/generate_api_reference.py
+++ b/docs/generate_api_reference.py
@@ -91,7 +91,7 @@ def write_module_doc(module_name):
 PACKAGE_DOC_TEMPLATE = """{title}
 
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 2
 
     {module_links}
 """


### PR DESCRIPTION
Refer people to the API reference pages instead of the code to browse what's available.

Also increases the depth of the table of contents on that page to make it more useful. 