### PR TITLE
Fixup docstring formatting

### DIFF
--- a/gnomad_hail/resources/grch37/gnomad.py
+++ b/gnomad_hail/resources/grch37/gnomad.py
@@ -287,6 +287,7 @@ def release_vcf_path(data_type: str, version: str, contig: str) -> str:
     """
     Publically released VCF. Provide specific contig, i.e. "20", to retrieve contig
     specific VCF
+
     :param str data_type: One of "exomes" or "genomes"
     :param str version: One of the release versions of gnomAD on GRCh37
     :param str contig: Single contig "1" to "Y"

--- a/gnomad_hail/resources/grch38/gnomad.py
+++ b/gnomad_hail/resources/grch38/gnomad.py
@@ -90,6 +90,7 @@ def release_vcf_path(data_type: str, version: str, contig: str) -> str:
     """
     Publically released VCF. Provide specific contig, i.e. "chr20", to retrieve contig
     specific VCF
+
     :param str data_type: One of "exomes" or "genomes"
     :param str version: One of the release versions of gnomAD on GRCh37
     :param str contig: Single contig "chr1" to "chrY"

--- a/gnomad_hail/resources/resource_utils.py
+++ b/gnomad_hail/resources/resource_utils.py
@@ -15,6 +15,7 @@ class BaseResource(ABC):
     def __init__(self, path: str, import_sources: Optional[Dict[str, Any]] = None, expected_file_extension: str = ""):
         """
         Creates a Resource
+
         :param str path: The resource path
         :param dict of str import_sources: Additional attributes for the resource
         """
@@ -48,6 +49,7 @@ class TableResource(BaseResource):
     def ht(self) -> hl.Table:
         """
         Read and return the Hail Table resource
+
         :return: Hail Table resource
         :rtype: Table
         """
@@ -69,6 +71,7 @@ class MatrixTableResource(BaseResource):
     def mt(self) -> hl.MatrixTable:
         """
         Read and return the Hail MatrixTable resource
+
         :return: Hail MatrixTable resource
         :rtype: MatrixTable
         """
@@ -90,6 +93,7 @@ class PedigreeResource(BaseResource):
     def ht(self, delimiter=r"\\s+") -> hl.Table:
         """
         Reads the pedigree into a family HT using hl.import_fam().
+
         :param str delimiter: Delimiter used in the ped file
         :return: Family table
         :rtype: Table
@@ -99,6 +103,7 @@ class PedigreeResource(BaseResource):
     def pedigree(self, delimiter=r"\\s+") -> hl.Pedigree:
         """
         Reads the pedigree into an hl.Pedigree using hl.Pedigree.read().
+
         :param str delimiter: Delimiter used in the ped file
         :return: pedigree
         :rtype: Pedigree
@@ -121,6 +126,7 @@ class BlockMatrixResource(BaseResource):
     def bm(self) -> BlockMatrix:
         """
         Read and return the Hail MatrixTable resource
+
         :return: Hail MatrixTable resource
         :rtype: MatrixTable
         """
@@ -138,6 +144,7 @@ class BaseVersionedResource(BaseResource, ABC):
         The `path`/`source_path` attributes of the versioned resource are those
         of the default version of the resource.
         In addition, all versions of the resource are stored in the `versions` attribute.
+
         :param str default_version: The default version of this resource (needs to be in the `versions` dict)
         :param dict of str -> BaseResource versions: A dict of version name -> resource.
         """

--- a/gnomad_hail/utils/annotations.py
+++ b/gnomad_hail/utils/annotations.py
@@ -11,7 +11,9 @@ def pop_max_expr(
     that has the highest AF from the populations provided in `freq_meta`,
     excluding those specified in `pops_to_exclude`.
     Only frequencies from adj populations are considered.
+
     This resulting struct contains the following fields:
+
     - AC: int32,
     - AF: float64,
     - AN: int32,
@@ -53,7 +55,9 @@ def project_max_expr(
     """
     Creates an expression that computes allele frequency information by project for the `n_projects` with the largest AF at this row.
     This return an array with one element per non-reference allele.
+
     Each of these elements is itself an array of structs with the following fields:
+
     - AC: int32,
     - AF: float64,
     - AN: int32,
@@ -300,8 +304,10 @@ def annotate_freq(
     :param StringExpression sex_expr: When specified, frequencies are stratified by sex. If `pop_expr` is also specified, then a pop/sex stratifiction is added.
     :param StringExpression pop_expr: When specified, frequencies are stratified by population. If `sex_expr` is also specified, then a pop/sex stratifiction is added.
     :param StringExpression subpop_expr: When specified, frequencies are stratified by sub-continental population. Note that `pop_expr` is required as well when using this option.
-    :param dict of str -> StringExpression additional_strata_expr: When specified, frequencies are stratified by the given additional strata found in the dict. This can e.g. be used to stratify by platform.
-    :param list of int downsamplings: When specified, frequencies are computed by downsampling the data to the number of samples given in the list. Note that if `pop_expr` is specified, downsamplings by population is also computed.
+    :param additional_strata_expr: When specified, frequencies are stratified by the given additional strata found in the dict. This can e.g. be used to stratify by platform.
+    :type additional_strata_expr: dict of str -> StringExpression
+    :param downsamplings: When specified, frequencies are computed by downsampling the data to the number of samples given in the list. Note that if `pop_expr` is specified, downsamplings by population is also computed.
+    :type downsamplings: list of int
     :return: MatrixTable with `freq` annotation
     """
 

--- a/gnomad_hail/utils/generic.py
+++ b/gnomad_hail/utils/generic.py
@@ -91,8 +91,9 @@ def get_reference_genome(
     """
     Returns the reference genome associated with the input Locus expression
 
-    :param LocusExpression or IntervalExpression locus: Input locus
-    :param  bool add_sequence: If set, the fasta sequence is added to the reference genome
+    :param locus: Input locus
+    :type locus: LocusExpression or IntervalExpression
+    :param bool add_sequence: If set, the fasta sequence is added to the reference genome
     :return: Reference genome
     :rtype: ReferenceGenome
     """
@@ -138,7 +139,8 @@ def filter_to_autosomes(t: Union[hl.MatrixTable, hl.Table]) -> Union[hl.MatrixTa
     Filters the Table or MatrixTable to autosomes only.
     This assumes that the input contains a field named `locus` of type Locus
 
-    :param MatrixTable or Table t: Input MT/HT
+    :param t: Input MT/HT
+    :type t: MatrixTable or Table
     :return:  MT/HT autosomes
     :rtype: MatrixTable or Table
     """
@@ -160,8 +162,10 @@ def get_sample_data(mt: hl.MatrixTable, fields: List[hl.expr.StringExpression], 
     """
     Hail devs hate this one simple py4j trick to speed up sample queries
 
-    :param MatrixTable or Table mt: MT
-    :param list of StringExpression fields: fields
+    :param mt:
+    :type mt: MatrixTable or Table
+    :param fields:
+    :type fields: list of StringExpression
     :param sep: Separator to use (tab usually fine)
     :param delim: Delimiter to use (pipe usually fine)
     :return: Sample data
@@ -213,9 +217,13 @@ def pc_project(
 
 def sample_pcs_uniformly(scores_table: hl.Table, num_pcs: int = 5, num_bins: int = 10, num_per_bin: int = 20) -> hl.Table:
     """
-    Sample somewhat uniformly in num_pcs-dimensional PC space, by:
+    Sample somewhat uniformly in num_pcs-dimensional PC space.
+
+    Works by:
+
     1. Binning each PC axis into num_bins bins, creating an array of num_pcs with num_bins possible values (total of num_bins ^ num_pcs sectors)
     2. For each k-dimensional sector, take up to num_per_bin samples
+
     Max number of samples return is num_per_bin * num_bins ^ num_pcs, but in practice, typically much fewer (corners of PC space are sparse)
 
     Assumes your scores are in scores_table.scores (and sample stored in `s`)
@@ -238,12 +246,14 @@ def filter_low_conf_regions(mt: Union[hl.MatrixTable, hl.Table], filter_lcr: boo
     """
     Filters low-confidence regions
 
-    :param MatrixTable or Table mt: MatrixTable or Table to filter
+    :param mt: MatrixTable or Table to filter
+    :param mt: MatrixTable or Table
     :param bool filter_lcr: Whether to filter LCR regions
     :param bool filter_decoy: Whether to filter decoy regions
     :param bool filter_segdup: Whether to filter Segdup regions
     :param bool filter_exome_low_coverage_regions: Whether to filter exome low confidence regions
-    :param list of str high_conf_regions: Paths to set of high confidence regions to restrict to (union of regions)
+    :param high_conf_regions: Paths to set of high confidence regions to restrict to (union of regions)
+    :type high_conf_regions: list of str
     :return: MatrixTable or Table with low confidence regions removed
     :rtype: MatrixTable or Table
     """
@@ -329,7 +339,8 @@ def vep_or_lookup_vep(ht, reference_vep_ht=None, reference=None, vep_config=None
 
 def add_most_severe_consequence_to_consequence(tc: hl.expr.StructExpression) -> hl.expr.StructExpression:
     """
-    Add most_severe_consequence annotation to transcript consequences
+    Add most_severe_consequence annotation to transcript consequences.
+
     This is for a given transcript, as there are often multiple annotations for a single transcript:
     e.g. splice_region_variant&intron_variant -> splice_region_variant
     """
@@ -710,10 +721,10 @@ def explode_trio_matrix(tm: hl.MatrixTable, col_keys: List[str] = ['s']) -> hl.M
     """
 
     Splits a trio MatrixTable back into a sample MatrixTable.
-    It assumes that the input MatrixTable schema
 
     :param MatrixTable tm: Input trio MatrixTable
-    :param list of str col_keys: Column keys for the sample MatrixTable
+    :param col_keys: Column keys for the sample MatrixTable
+    :type col_keys: list of str
     :return: Sample MatrixTable
     :rtype: MatrixTable
     """
@@ -748,7 +759,6 @@ def get_duplicated_samples(
 ) -> List[Set[str]]:
     """
     Given a pc_relate output Table, extract the list of duplicate samples. Returns a list of set of samples that are duplicates.
-
 
     :param Table kin_ht: pc_relate output table
     :param str i_col: Column containing the 1st sample
@@ -1021,8 +1031,10 @@ def assign_population_pcs(
         If you have a Pandas Dataframe and have all PCs as an array in a single column, the
         `expand_pd_array_col` can be used to expand this column into multiple `PC` columns.
 
-    :param Table or DataFrame pop_pc_pd: Input Hail Table or Pandas Dataframe
-    :param ArrayExpression or list of str pc_cols: Columns storing the PCs to use
+    :param pop_pc_pd: Input Hail Table or Pandas Dataframe
+    :type pop_pc_pd: Table or DataFrame
+    :param pc_cols: Columns storing the PCs to use
+    :type pc_cols: ArrayExpression or list of str
     :param str known_col: Column storing the known population labels
     :param RandomForestClassifier fit: fit from a previously trained random forest model (i.e., the output from a previous RandomForestClassifier() call)
     :param int seed: Random seed
@@ -1102,7 +1114,9 @@ def assign_population_pcs(
 def merge_stats_counters_expr(stats: hl.expr.ArrayExpression) -> hl.expr.StructExpression:
     """
     Merges multiple stats counters, assuming that they were computed on non-overlapping data.
+
     Examples:
+
     - Merge stats computed on indel and snv separately
     - Merge stats computed on bi-allelic and multi-allelic variants separately
     - Merge stats computed on autosomes and sex chromosomes separately
@@ -1177,7 +1191,8 @@ def bi_allelic_expr(t: Union[hl.Table, hl.MatrixTable]) -> hl.expr.BooleanExpres
     Returns a boolean expression selecting bi-allelic sites only,
     accounting for whether the input MT/HT was split.
 
-    :param Table or MatrixTable t: Input HT/MT
+    :param t: Input HT/MT
+    :type t: Table or MatrixTable
     :return: Boolean expression selecting only bi-allelic sites
     :rtype: BooleanExpression
     """
@@ -1187,6 +1202,7 @@ def bi_allelic_expr(t: Union[hl.Table, hl.MatrixTable]) -> hl.expr.BooleanExpres
 def bi_allelic_site_inbreeding_expr(call: hl.expr.CallExpression) -> hl.expr.Float32Expression:
     """
     Return the site inbreeding coefficient as an expression to be computed on a MatrixTable.
+
     This is implemented based on the GATK InbreedingCoeff metric:
     https://software.broadinstitute.org/gatk/documentation/article.php?id=8032
 
@@ -1260,7 +1276,8 @@ def fs_from_sb(
 
     GATK code here: https://github.com/broadinstitute/gatk/blob/master/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/FisherStrand.java
 
-    :param ArrayNumericExpression or ArrayExpression sb: Count of ref/alt reads on each strand
+    :param sb: Count of ref/alt reads on each strand
+    :type sb: ArrayNumericExpression or ArrayExpression
     :param bool normalize: Whether to normalize counts is sum(counts) > min_cell_count (normalize=True), or use a chi sq instead of FET (normalize=False)
     :param int min_cell_count: Maximum count for performing a FET
     :param int min_count: Minimum total count to output FS (otherwise null it output)
@@ -1326,6 +1343,7 @@ def vep_struct_to_csq(
 ) -> hl.expr.ArrayExpression:
     """
     Given a VEP Struct, returns and array of VEP VCF CSQ strings (one per consequence in the struct).
+
     The fields and their order will correspond to those passed in `csq_fields`, which corresponds to the
     VCF header that is required to interpret the VCF CSQ INFO field.
 
@@ -1422,7 +1440,7 @@ def get_median_and_mad_expr(
         )
     )
 
-                            
+
 def get_array_element_type(array_expr: hl.expr.ArrayExpression) -> hl.HailType:
     """
     Returns the type of an array element.
@@ -1447,6 +1465,7 @@ def ht_to_vcf_mt(
 
     :param Table info_ht: Input HT
     :param pipe_delimited_annotations: List of info fields (they must be fields of the ht.info Struct)
+    :type pipe_delimited_annotations: list of str
     :return: MatrixTable ready for VCF export
     :rtype: MatrixTable
     """
@@ -1502,7 +1521,8 @@ def sort_intervals(intervals: List[hl.Interval]):
     Sorts an array of intervals by:
     start contig, then start position, then end contig, then end position
 
-    :param list of Interval intervals: Intervals to sort
+    :param intervals: Intervals to sort
+    :type intervals: list of Interval
     :return: Sorted interval list
     :rtype: list of Interval
     """
@@ -1521,7 +1541,8 @@ def union_intervals(intervals: List[hl.Interval], is_sorted: bool = False):
     """
     Generates a list with the union of all intervals in the input list by merging overlapping intervals.
 
-    :param list of Interval intervals: Intervals to merge
+    :param intervals: Intervals to merge
+    :type intervals: list of Interval
     :param bool is_sorted: If set, assumes intervals are already sorted, otherwise will sort.
     :return: List of merged intervals
     :rtype: List of Interval

--- a/gnomad_hail/utils/generic.py
+++ b/gnomad_hail/utils/generic.py
@@ -247,7 +247,7 @@ def filter_low_conf_regions(mt: Union[hl.MatrixTable, hl.Table], filter_lcr: boo
     Filters low-confidence regions
 
     :param mt: MatrixTable or Table to filter
-    :param mt: MatrixTable or Table
+    :type mt: MatrixTable or Table
     :param bool filter_lcr: Whether to filter LCR regions
     :param bool filter_decoy: Whether to filter decoy regions
     :param bool filter_segdup: Whether to filter Segdup regions

--- a/gnomad_hail/utils/gnomad_functions.py
+++ b/gnomad_hail/utils/gnomad_functions.py
@@ -93,12 +93,12 @@ def adjusted_sex_ploidy_expr(
 ) -> hl.expr.CallExpression:
     """
     Creates an entry expression to convert males to haploid on non-PAR X/Y and females to missing on Y
-    
+
     :param LocusExpression locus_expr: Locus
     :param CallExpression gt_expr: Genotype
     :param StringExpression karyotype_expr: Karyotype
     :param str xy_karyotype_str: Male sex karyotype representation
-    :param xx_karyotype_str: Female sex karyotype representation
+    :param str xx_karyotype_str: Female sex karyotype representation
     :return: Genotype adjusted for sex ploidy
     :rtype: CallExpression
     """
@@ -143,7 +143,7 @@ def read_list_data(input_file_path: str) -> List[str]:
     """
     Reads a file input into a python list (each line will be an element).
     Supports Google storage paths and .gz compression.
-    
+
     :param str input_file_path: File path
     :return: List of lines
     :rtype: List
@@ -182,10 +182,13 @@ def filter_by_frequency(t: Union[hl.MatrixTable, hl.Table], direction: str,
     """
     Filter MatrixTable or Table with gnomAD-format frequency data (assumed bi-allelic/split)
     (i.e. Array[Struct(Array[AC], Array[AF], AN, homozygote_count, meta)])
+
     At least one of frequency or allele_count is required.
+
     Subpop can be specified without a population if desired.
 
-    :param MatrixTable or Table t: Input MatrixTable or Table
+    :param t: Input MatrixTable or Table
+    :type t: MatrixTable or Table
     :param str direction: One of "above", "below", and "equal" (how to apply the filter)
     :param float frequency: Frequency to filter by (one of frequency or allele_count is required)
     :param int allele_count: Allele count to filter by (one of frequency or allele_count is required)
@@ -281,7 +284,8 @@ def add_rank(ht: hl.Table,
 
     :param Table ht: input Hail Table containing variants (with QC annotations) to be ranked
     :param NumericExpression score_expr: the Table annotation by which ranking should be scored
-    :param dict str -> BooleanExpression subrank_expr: Any subranking to be added in the form name_of_subrank: subrank_filtering_expr
+    :param subrank_expr: Any subranking to be added in the form name_of_subrank: subrank_filtering_expr
+    :type subrank_expr: dict of str -> BooleanExpression
     :return: Table with rankings added
     :rtype: Table
     """

--- a/gnomad_hail/utils/ld.py
+++ b/gnomad_hail/utils/ld.py
@@ -24,12 +24,14 @@ def get_r_for_pair_of_variants(bm: BlockMatrix, ld_index: hl.Table,
     """
     Get `r` value (LD) for pair of variants `var1` and `var2`.
 
-    bm = get_ld_matrix('nfe')
-    ld_index = get_ld_index('nfe')
-    var1 = (hl.parse_locus('1:10146', 'GRCh37'), ['AC', 'A'])
-    var2 = (hl.parse_locus('1:10151', 'GRCh37'), ['TA', 'T'])
-    get_r_for_pair_of_variants(bm, ld_index, var1, var2)
-    # 0.01789767935482124
+    .. code-block:: python
+
+        bm = get_ld_matrix('nfe')
+        ld_index = get_ld_index('nfe')
+        var1 = (hl.parse_locus('1:10146', 'GRCh37'), ['AC', 'A'])
+        var2 = (hl.parse_locus('1:10151', 'GRCh37'), ['TA', 'T'])
+        get_r_for_pair_of_variants(bm, ld_index, var1, var2)
+        # 0.01789767935482124
 
     :param BlockMatrix bm: Input BlockMatrix
     :param Table ld_index: Corresponding index table

--- a/gnomad_hail/utils/liftover.py
+++ b/gnomad_hail/utils/liftover.py
@@ -16,6 +16,7 @@ logger.setLevel(logging.INFO)
 def get_checkpoint_path(gnomad: bool, data_type: str, path: str, is_table: bool) -> str:
     """
     Creates a checkpoint path for Table
+
     :param bool gnomad: Whether data is gnomAD data
     :param str data_type: Data type (exomes or genomes for gnomAD; not used otherwise)
     :param str path: Path to input Table/MatrixTable (if data is not gnomAD data)
@@ -36,7 +37,8 @@ def get_liftover_genome(t: Union[hl.MatrixTable, hl.Table]) -> list:
     """
     Infers genome build of input data and assumes destination build. Prepares to liftover to destination genome build
 
-    :param Table/MatrixTable t: Input Table or MatrixTable
+    :param t: Input Table or MatrixTable
+    :type t: Table or MatrixTable
     :return: List of source build (with liftover chain added) and destination build (with sequence loaded)
     :rtype: List (containing type hl.genetics.ReferenceGenome)
     """
@@ -71,7 +73,8 @@ def lift_data(t: Union[hl.MatrixTable, hl.Table], gnomad: bool, data_type: str, 
     """
     Lifts input Table or MatrixTable from one reference build to another
 
-    :param Table/MatrixTable t: Table or MatrixTable
+    :param t: Table or MatrixTable
+    :type t: Table or MatrixTable
     :param bool gnomad: Whether data is gnomAD data
     :param str data_type: Data type (exomes or genomes for gnomAD; not used otherwise)
     :param str path: Path to input Table/MatrixTable (if data is not gnomAD data)
@@ -111,7 +114,9 @@ def annotate_snp_mismatch(t: Union[hl.MatrixTable, hl.Table], data_type: str, rg
     Annotates mismatches between reference allele and allele in reference fasta
 
     Assumes input Table/MatrixTable has t.new_locus annotation
-    :param Table/MatrixTable t: Table/MatrixTable of SNPs to be annotated
+
+    :param t: Table/MatrixTable of SNPs to be annotated
+    :type t: Table or MatrixTable
     :param str data_type: Data type (exomes or genomes for gnomAD; not used otherwise)
     :param ReferenceGenome rg: Reference genome with fasta sequence loaded
     :return: Table annotated with mismatches between reference allele and allele in fasta
@@ -135,6 +140,7 @@ def annotate_snp_mismatch(t: Union[hl.MatrixTable, hl.Table], data_type: str, rg
 def check_mismatch(ht: hl.Table) -> hl.expr.expressions.StructExpression:
     """
     Checks for mismatches between reference allele and allele in reference fasta
+
     :param Table ht: Table to be checked
     :return: StructExpression containing counts for mismatches and count for all variants on negative strand
     :rtype: StructExpression

--- a/gnomad_hail/utils/plotting.py
+++ b/gnomad_hail/utils/plotting.py
@@ -177,13 +177,19 @@ def plot_multi_hail_hist(hist_data: Dict[str, hl.Struct],
     Each histogram can (and should) come straight from ht.aggregate(hl.agg.hist(ht.data, start, end, bins))
 
     Example usage:
-    plot_multi_hail_hist(ht.aggregate(hl.agg.group_by(ht.pop, hl.agg.hist(ht.data, start, end, bins))))
 
-    :param dict of str -> Struct hist_data: Data to plot
+    .. code-block:: python
+
+        plot_multi_hail_hist(ht.aggregate(hl.agg.group_by(ht.pop, hl.agg.hist(ht.data, start, end, bins))))
+
+    :param hist_data: Data to plot
+    :type hist_data: dict of str -> Struct
     :param str title: Plot title
     :param bool log: Whether the y-axis should be log
-    :param dict of str ->str fill_color: Color to fill the histogram bars that fall within the hist boundaries
-    :param dict of str -> str outlier_fill_color: Color to fill the histogram bars that fall outside the hist boundaries
+    :param fill_color: Color to fill the histogram bars that fall within the hist boundaries
+    :type fill_color: dict of str -> str
+    :param outlier_fill_color: Color to fill the histogram bars that fall outside the hist boundaries
+    :type outlier_fill_color: dict of str -> str
     :param str line_color: Color of the lines around the histogram bars
     :param str hover_mode: Hover mode; one of 'mouse' (default), 'vline' or 'hline'
     :param bool hide_zeros: Remove hist bars with 0 count
@@ -304,9 +310,9 @@ def linear_and_log_tabs(plot_func: Callable, **kwargs) -> Tabs:
 
 def plot_hail_file_metadata(t_path: str) -> Optional[Union[Grid, Tabs, bokeh.plotting.Figure]]:
     """
-    Takes path to hail Table or MatrixTable (gs://bucket/path/hail.mt), outputs Grid or Tabs, respectively
-    Or if an unordered Table is provided, a Figure with file sizes is output
-    If metadata file or rows directory is missing, returns None
+    Takes path to hail Table or MatrixTable (gs://bucket/path/hail.mt), outputs Grid or Tabs, respectively.
+    Or if an unordered Table is provided, a Figure with file sizes is output.
+    If metadata file or rows directory is missing, returns None.
     """
     panel_size = 600
     subpanel_size = 150
@@ -495,19 +501,22 @@ def pair_plot(
         tooltip_cols: List[str] = None
 ) -> Column:
     """
-
     Plots each column of `data` against each other and returns a grid of plots.
+
     The diagonal contains a histogram of each column, or a density plot if labels are provided.
     The lower diagonal contains scatter plots of each column against each other.
     The upper diagonal is empty.
+
     All columns should be numerical with the exception of the `label_col` if provided.
     If a color dict containing provided mapping labels to specific colors can be specified using `color_dict`
 
     :param DataFrame data: Dataframe to plot
     :param str label_col: Column of the DataFrame containing the labels
-    :param list of str or dict of str -> str colors: RGB hex colors. If a dict is provided, it should contain the mapping of label to colors.
+    :param colors: RGB hex colors. If a dict is provided, it should contain the mapping of label to colors.
+    :type colors: list or str or dict of str -> str
     :param str tools: Tools for the resulting plots
-    :param list of str tooltip_cols: Additional columns that should be displayed in tooltip
+    :param tooltip_cols: Additional columns that should be displayed in tooltip
+    :type tooltip_cols: list of str
     :return: Grid of plots (column of rows)
     :rtype: Column
     """

--- a/gnomad_hail/utils/rf.py
+++ b/gnomad_hail/utils/rf.py
@@ -14,7 +14,8 @@ def run_rf_test(
         output: str = '/tmp'
 ) -> Tuple[pyspark.ml.PipelineModel, hl.MatrixTable]:
     """
-    Runs a dummy test RF on a given MT:
+    Runs a dummy test RF on a given MT.
+
     1. Creates row annotations and labels to run model on
     2. Trains a RF pipeline model (including median imputation of missing values in created annotations)
     3. Saves the RF pipeline model
@@ -76,7 +77,8 @@ def check_ht_fields_for_spark(ht: hl.Table, fields: List[str]) -> None:
     Checks specified fields of a hail table for Spark DataFrame conversion (type and name)
 
     :param Table ht: input Table
-    :param list of str fields: Fields to test
+    :param fields: Fields to test
+    :type fields: list of str
     :return: None
     :rtype: None
     """
@@ -103,14 +105,16 @@ def get_columns_quantiles(
         relative_error: int = 0.001
 ) -> Dict[str, List[float]]:
     """
-    Computes approximate quantiles of specified numeric fields from non-missing values.
-    Non-numeric fields are ignored.
+    Computes approximate quantiles of specified numeric fields from non-missing values. Non-numeric fields are ignored.
+
     This function returns a Dict of column name -> list of quantiles in the same order specified.
     If a column only has NAs, None is returned.
 
     :param Table ht: input HT
-    :param list of str fields: list of features to impute. If none given, all numerical features with missing data are imputed
-    :param list of float quantiles: list of quantiles to return (e.g. [0.5] would return the median)
+    :param fields: list of features to impute. If none given, all numerical features with missing data are imputed
+    :type fields: list of str
+    :param quantiles: list of quantiles to return (e.g. [0.5] would return the median)
+    :type quantiles: list of float
     :param float relative_error: The relative error on the quantile approximation
     :return: Dict of column -> quantiles
     :rtype: dict of str -> list of float
@@ -139,14 +143,17 @@ def ht_to_rf_df(
         index: str = None
 ) -> pyspark.sql.DataFrame:
     """
-
     Creates a Spark dataframe ready for RF from a HT.
     Rows with any missing features are dropped.
     Missing labels are replaced with 'NA'
-    Note: Only basic types are supported!
+
+    .. note::
+
+        Only basic types are supported!
 
     :param Table ht: Input HT
-    :param list of str features: Features that will be used for RF
+    :param features: Features that will be used for RF
+    :type features: list of str
     :param str label: Label column that will be predicted by RF
     :param str index: Optional index column to keep (E.g. for joining results back at later stage)
     :return: Spark Dataframe
@@ -205,14 +212,16 @@ def test_model(
         prediction_col_name: str = 'rf_prediction'
 ) -> List[hl.tstruct]:
     """
-    A wrapper to test a model on a set of examples with known labels:
+    A wrapper to test a model on a set of examples with known labels.
+
     1) Runs the model on the data
     2) Prints confusion matrix and accuracy
     3) Returns confusion matrix as a list of struct
 
     :param Table ht: Input table
     :param PipelineModel rf_model: RF Model
-    :param list of str features: Columns containing features that were used in the model
+    :param features: Columns containing features that were used in the model
+    :type features: list of str
     :param str label: Column containing label to be predicted
     :param str prediction_col_name: Where to store the prediction
     :return: A list containing structs with {label, prediction, n}
@@ -252,7 +261,8 @@ def apply_rf_model(
 
     :param MatrixTable ht: Input HT
     :param PipelineModel rf_model: Random Forest pipeline model
-    :param list of str features: List of feature columns in the pipeline. !Should match the model list of features!
+    :param features: List of feature columns in the pipeline. !Should match the model list of features!
+    :type features: list of str
     :param str label: Column containing the labels. !Should match the model labels!
     :param str probability_col_name: Name of the column that will store the RF probabilities
     :param str prediction_col_name: Name of the column that will store the RF predictions
@@ -349,7 +359,8 @@ def train_rf(
     Trains a Random Forest (RF) pipeline model.
 
     :param Table ht: Input HT
-    :param list of str features: List of columns to be used as features
+    :param features: List of columns to be used as features
+    :type features: list of str
     :param str label: Column containing the label to predict
     :param int num_trees: Number of trees to use
     :param int max_depth: Maximum tree depth

--- a/gnomad_hail/utils/sparse_mt.py
+++ b/gnomad_hail/utils/sparse_mt.py
@@ -9,6 +9,7 @@ def compute_last_ref_block_end(mt: hl.MatrixTable) -> hl.Table:
     """
     This function takes a sparse MT and computes for each row the genomic position of the
     most upstream reference block overlapping that row.
+
     Note that since reference blocks do not extend beyond contig boundaries, only the position is kept.
 
     This function returns a Table with that annotation.  (`last_END_position`).
@@ -65,6 +66,7 @@ def densify_sites(
 ) -> hl.MatrixTable:
     """
     Creates a dense version of the input sparse MT at the sites in `sites_ht` reading the minimal amount of data required.
+
     Note that only rows that appear both in `mt` and `sites_ht` are returned.
 
     :param MatrixTable mt: Input sparse MT
@@ -247,9 +249,12 @@ def get_as_info_expr(
        Priority is given to entry fields in `mt` over those in `mt.gvcf_info` in case of a name clash.
 
     :param MatrixTable mt: Input Matrix Table
-    :param list of str or dict of str -> NumericExpression sum_agg_fields: Fields to aggregate using sum.
-    :param list of str or dict of str -> NumericExpression int32_sum_agg_fields: Fields to aggregate using sum using int32.
-    :param list of str or dict of str -> NumericExpression median_agg_fields: Fields to aggregate using (approximate) median.
+    :param sum_agg_fields: Fields to aggregate using sum.
+    :type sum_agg_fields: list of str or dict of str -> NumericExpression
+    :param int32_sum_agg_fields: Fields to aggregate using sum using int32.
+    :type int32_sum_agg_fields: list of str or dict of str -> NumericExpression
+    :param median_agg_fields: Fields to aggregate using (approximate) median.
+    :type median_agg_fields: list of str or dict of str -> NumericExpression
     :return: Expression containing the AS info fields
     :rtype: StructExpression
     """
@@ -326,9 +331,12 @@ def get_site_info_expr(
        Priority is given to entry fields in `mt` over those in `mt.gvcf_info` in case of a name clash.
 
     :param MatrixTable mt: Input Matrix Table
-    :param list of str or dict of str -> NumericExpression sum_agg_fields: Fields to aggregate using sum.
-    :param list of str or dict of str -> NumericExpression int32_sum_agg_fields: Fields to aggregate using sum using int32.
-    :param list of str or dict of str -> NumericExpression median_agg_fields: Fields to aggregate using (approximate) median.
+    :param sum_agg_fields: Fields to aggregate using sum.
+    :type sum_agg_fields: list of str or dict of str -> NumericExpression
+    :param int32_sum_agg_fields: Fields to aggregate using sum using int32.
+    :type int32_sum_agg_fields: list of str or dict of str -> NumericExpression
+    :param median_agg_fields: Fields to aggregate using (approximate) median.
+    :type median_agg_fields: list of str or dict of str -> NumericExpression
     :return: Expression containing the site-level info fields
     :rtype: StructExpression
     """

--- a/gnomad_hail/utils/variant_qc.py
+++ b/gnomad_hail/utils/variant_qc.py
@@ -15,7 +15,8 @@ def get_lowqual_expr(
     Computes lowqual threshold expression for either split or unsplit alleles based on QUALapprox or AS_QUALapprox
 
     :param ArrayExpression alleles: Array of alleles
-    :param ArraynumericExpression or NumericExpression qual_approx_expr: QUALapprox or AS_QUALapprox
+    :param qual_approx_expr: QUALapprox or AS_QUALapprox
+    :type qual_approx_expr: ArraynumericExpression or NumericExpression
     :param int snv_phred_threshold: Phred-scaled SNV "emission" threshold (similar to GATK emission threshold)
     :param int snv_phred_het_prior: Phred-scaled SNV heterozygosity prior (30 = 1/1000 bases, GATK default)
     :param int indel_phred_threshold: Phred-scaled indel "emission" threshold (similar to GATK emission threshold)
@@ -43,6 +44,7 @@ def generate_fam_stats_expr(
 ) -> hl.expr.StructExpression:
     """
     Generates a row-wise expression containing the following counts:
+
     - Number of alleles in het parents transmitted to the proband
     - Number of alleles in het parents not transmitted to the proband
     - Number of de novo mutations
@@ -51,8 +53,10 @@ def generate_fam_stats_expr(
     If an empty dict is passed as one of the strata arguments, then this metric isn't computed.
 
     :param MatrixTable trio_mt: A trio standard trio MT (with the format as produced by hail.methods.trio_matrix
-    :param dict of str -> BooleanExpression transmitted_strata: Strata for the transmission counts
-    :param dict of str -> BooleanExpression de_novo_strata: Strata for the de novo counts
+    :param transmitted_strata: Strata for the transmission counts
+    :type transmitted_strata: dict of str -> BooleanExpression
+    :param de_novo_strata: Strata for the de novo counts
+    :type de_novo_strata: dict of str -> BooleanExpression
     :param BooleanExpression proband_is_female_expr: An optional expression giving the sex the proband. If not given, DNMs are only computed for autosomes.
     :return: An expression with the counts
     :rtype: StructExpression
@@ -199,6 +203,7 @@ def compute_binned_rank(
 ) -> hl.Table:
     """
     Returns a table containing a binned rank for each row.
+
     The bin is computed by dividing the `score_expr` into `n_bins` bins containing an equal number of elements.
     This is done based on quantiles computed with hl.agg.approx_quantiles.
     If a single value in `score_expr` spans more than one bin, the rows with this value are distributed
@@ -215,7 +220,8 @@ def compute_binned_rank(
 
     :param Table ht: Input Table
     :param NumericExpression score_expr: Expression containing the score
-    :param dict of str -> BooleanExpression rank_expr: Rank(s) to be computed (see notes)
+    :param rank_expr: Rank(s) to be computed (see notes)
+    :type rank_expr: dict of str -> BooleanExpression
     :param int n_bins: Number of bins to bin the data into
     :param int k: The `k` parameter of approx_quantiles
     :param bool desc: Whether to bin the score in descending order


### PR DESCRIPTION
Fix docstring formatting. For example, without a space between the summary line and parameter list, Sphinx won't format the parameter list.

Also (annoyingly) Sphinx can't parse multi-word types in parameter descriptions. So `:param list of str foo:` has to be replaced with:
```
:param foo:
:type foo: list of str
```

Some time, I'll look into whether it's possibly to pull the parameter types from the type annotations instead of the docstring.