### PR TITLE
Change instructions for serving docs to work with Python 3.6

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,10 @@ pip install -r docs/requirements.txt
 The generated HTML is placed in docs/html. To view the documentation, run:
 
 ```
-python3 -m http.server -d docs/html
+(cd docs/html && python3 -m http.server)
 ```
+
+and open http://localhost:8000 in a web browser.
 
 ## References
 


### PR DESCRIPTION
@lfrancioli and I discovered today that the `-d` option for http.server was only added in Python 3.7.

This change replaces the `-d` usage in the instructions for serving the docs locally with `cd` so that the documented command works with Python 3.6. It also adds a note on where to view the docs once the server is running.